### PR TITLE
[FIX] Solved VersionDict copy issue 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist
 MANIFEST
 .cache
 *token.txt
+.python-version
+build/

--- a/extradict/version_dict.py
+++ b/extradict/version_dict.py
@@ -41,6 +41,8 @@ class VersionDict(MutableMapping):
 
     def copy(self, version=None):
         new = VersionDict.__new__(self.__class__)
+        new.local = threading.local()
+        new.local._updating = False
         new._init_lock()
         if version is None or version >= self.version:
             new._version = self._version

--- a/tests/test_version_dict.py
+++ b/tests/test_version_dict.py
@@ -1,6 +1,6 @@
-from extradict import VersionDict as VD
-
 import pytest
+
+from extradict import VersionDict as VD
 
 
 @pytest.fixture
@@ -45,3 +45,20 @@ def test_vd_raises_keyerror(vd):
 
 def test_vd_update_increases_version_in_one_number(vd):
     pass
+
+
+def test_vd_copy_no_version(vd):
+    vd["a"] = 1
+    vd_copy = vd.copy()
+
+    assert vd._version == vd_copy._version
+
+    vd_copy["a"] = 2
+    assert vd._version != vd_copy._version
+
+
+def test_vd_copy_new_version(vd):
+    vd["a"] = 1
+    vd_copy = vd.copy(version=0)
+
+    assert vd_copy._version != vd._version


### PR DESCRIPTION
When we create a copy of an instance of a `VersionDict` object using the `copy` method, the attributes are not initialized since we use the `__new__` special method iof `__init__` which means that we need to add the instantiated values ourselves (immutable obj).